### PR TITLE
Change machine empires to respect habitability (somewhat).

### DIFF
--- a/common/species_classes/00_species_classes.txt
+++ b/common/species_classes/00_species_classes.txt
@@ -1,0 +1,317 @@
+# Number of entries controlls amount to choose from in designer  I.E.   "mol1" "mol2" "mol3" "mol4"
+# graphical_culture is connected to the looks used for ships and cities, see "common/graphical_culture/"
+# Portraits here are one you can choose from in the character creater. For prescripted races they are grabbed straight from the .gfx file. 
+# playable=(yes/no)/trigger, default is yes, if this species class can is playable
+# randomized=(yes/no)/trigger, default is yes, if this species class is randomized
+# custom_portraits
+#	randomized = trigger, default is no, to specify if portraits are randomized
+#	playable = trigger, default is yes, to specify if portraits are playable
+#	portraits, list portrait keys
+# species_trait_points: base number of species trait points available for this species class
+# species_max_traits: maximum number of traits that species of this class can have (doesn't count those with cost == 0)
+# possible: ethics/government requirements; see common/governments/readme_requirements.txt
+# gender: yes|no (default: yes). whether the species have a gender
+# portrait_modding: yes|no (default: no). whether the portrait can be modified with genemodding/robomodding
+
+HUM = {
+	archetype = BIOLOGICAL
+
+	possible = { authority = { NOT = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_NOT_USE_MACHINE_INTELLIGENCE } } }
+
+	portraits = {
+		"human"
+		"humanoid_02"
+		"humanoid_03"
+		"humanoid_04"
+		"humanoid_05"
+	}
+	custom_portraits = {
+		randomized = { host_has_dlc = "Humanoids Species Pack" }
+		playable = { local_has_dlc = "Humanoids Species Pack" }
+		portraits = {
+			"humanoid_hp_01"
+			"humanoid_hp_02"
+			"humanoid_hp_06"
+			"humanoid_hp_07"
+			"humanoid_hp_08"
+			"humanoid_hp_09"
+			"humanoid_hp_10"
+			"humanoid_hp_11"
+			"humanoid_hp_12"
+			"humanoid_hp_13"
+		}
+	}
+	
+	# These should not be used for randomly generated species
+	non_randomized_portraits = {
+		"human"
+	}
+	
+	graphical_culture = humanoid_01
+	move_pop_sound_effect = "moving_pop_confirmation"
+} 
+
+PRE_MAM = {
+	archetype = PRESAPIENT
+
+	playable = { always = no }
+	randomized = no
+
+	portraits = {
+		"pre_mam6"
+		"pre_mam13"
+	}
+
+	graphical_culture = mammalian_01
+	move_pop_sound_effect = "moving_pop_confirmation"
+	uplifted_into = "MAM"
+	uplifted_portraits = 
+	{
+		"mam6"
+		"mam13"	
+	}
+}
+
+PRE_REP = {
+	archetype = PRESAPIENT
+
+	playable = { always = no }
+	randomized = no
+
+	portraits = {
+		"pre_rep09"
+		"pre_rep12"
+	}
+
+	graphical_culture = reptilian_01
+	move_pop_sound_effect = "reptilian_pops_move"
+	uplifted_into = "REP"
+	uplifted_portraits = 
+	{
+		"rep9"
+		"rep12"	
+	}
+}
+
+PRE_AVI = {
+	archetype = PRESAPIENT
+	
+	playable = { always = no }
+	randomized = no
+
+	portraits = {
+		"pre_avi1"
+		"pre_avi12"
+	}
+
+	graphical_culture = avian_01
+	move_pop_sound_effect = "avian_pops_move"
+	uplifted_into = "AVI"
+	uplifted_portraits = 
+	{
+		"avi1"
+		"avi12"	
+	}
+}
+
+PRE_ART = {
+	archetype = PRESAPIENT
+	
+	playable = { always = no }
+	randomized = no
+
+	portraits = {
+		"pre_art1"
+		"pre_art11"
+		"pre_art12"
+		"pre_art13"
+		"pre_art14"
+		"pre_art15"
+	}
+
+	graphical_culture = arthropoid_01
+	move_pop_sound_effect = "arthopoid_pops_move"
+	uplifted_into = "ART"
+	uplifted_portraits = {
+		"art1"
+		"art11"
+		"art12"
+		"art13"
+		"art14"
+		"art15"
+	}
+}
+
+PRE_MOL = {
+	archetype = PRESAPIENT
+	
+	playable = { always = no }
+	randomized = no
+
+	portraits = {
+		"pre_mol1"
+		"pre_mol3"
+	}
+
+	graphical_culture = molluscoid_01
+	move_pop_sound_effect = "molluscoid_pops_move"
+	uplifted_into = "MOL"
+	uplifted_portraits = {
+		"mol1"
+		"mol3"
+	}
+}
+
+PRE_FUN = {
+	archetype = PRESAPIENT
+	
+	playable = { always = no }
+	randomized = no
+
+	gender = no
+
+	portraits = {
+		"pre_fun9"
+		"pre_fun13"
+	}
+
+	graphical_culture = fungoid_01
+	move_pop_sound_effect = "fungoid_pops_move"
+	uplifted_into = "FUN"
+	uplifted_portraits = {
+		"fun9"
+		"fun13"
+	}
+}
+
+
+AI = {
+	playable = { always = no }
+	randomized = no
+
+	gender = no
+
+	portraits = {
+		"hum_robot_red"
+	}
+	
+	graphical_culture = ai_01
+	move_pop_sound_effect = "moving_pop_confirmation"
+
+	resources = {}
+}
+
+SWARM = {
+	archetype = OTHER
+
+	playable = { always = no }
+	randomized = no
+
+	gender = no
+
+	portraits = {
+		"swarm"
+	}
+	
+	graphical_culture = swarm_01
+	move_pop_sound_effect = "moving_pop_confirmation"
+}
+
+EXD = {
+	archetype = OTHER
+
+	playable = { always = no }
+	randomized = no
+
+	gender = no
+
+	portraits = {
+		"exd1"
+		"exd2"		# No textures
+		"exd3"		# No textures
+	}
+
+	graphical_culture = extra_dimensional_01
+	move_pop_sound_effect = "moving_pop_confirmation"
+}
+
+ROBOT = {
+	archetype = ROBOT
+
+	playable = { has_global_flag = game_started }
+	randomized = no
+	robotic = yes
+	gender = no
+	use_climate_preference = no
+	portrait_modding = yes
+	
+	leader_age_min = 2
+	leader_age_max = 10
+	
+	custom_portraits = {
+		randomized = { host_has_dlc = "Synthetic Dawn Story Pack" }
+		playable = { host_has_dlc = "Synthetic Dawn Story Pack" }
+		portraits = {
+			"sd_hum_robot"
+			"sd_mam_robot"
+			"sd_rep_robot"
+			"sd_avi_robot"
+			"sd_art_robot"
+			"sd_mol_robot"
+			"sd_fun_robot"
+			"sd_pla_robot"
+		}
+	}
+
+	custom_portraits = { # use custom_portraits instead of portraits so we can put them after the custom_portraits above
+		randomized = { always = yes }
+		playable = { always = yes }
+		portraits = {
+			"default_robot"
+		}
+	}
+	
+	graphical_culture = ai_01
+	move_pop_sound_effect = "robot_pops_move"
+
+	resources = {}
+}
+
+MACHINE = {
+	archetype = MACHINE
+
+	playable = { host_has_dlc = "Synthetic Dawn Story Pack" }
+	randomized = {
+		host_has_dlc = "Synthetic Dawn Story Pack"
+		# The create_species effect can't properly take the possible trigger below into account.
+		# Work around this by disabling this class for species randomization after game start.
+		NOT = { has_global_flag = game_started }
+	}
+	possible = { authority = { OR = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_USE_MACHINE_INTELLIGENCE } } }
+	possible_secondary = { always = no text = SECONDARY_SPECIES_CLASS_INVALID }
+
+	robotic = yes
+	gender = no
+	use_climate_preference = yes
+	portrait_modding = yes
+	
+	leader_age_min = 2
+	leader_age_max = 10
+
+	portraits = {
+		"sd_hum_robot"
+		"sd_mam_robot"
+		"sd_rep_robot"
+		"sd_avi_robot"
+		"sd_art_robot"
+		"sd_mol_robot"
+		"sd_fun_robot"
+		"sd_pla_robot"
+		"default_robot"
+	}
+
+	graphical_culture = mammalian_01
+	move_pop_sound_effect = "robot_pops_move"
+
+	resources = {}
+}

--- a/common/species_classes/00_species_classes.txt
+++ b/common/species_classes/00_species_classes.txt
@@ -292,7 +292,7 @@ MACHINE = {
 
 	robotic = yes
 	gender = no
-	use_climate_preference = yes
+	use_climate_preference = yes # changed from 'no' to give them habitability
 	portrait_modding = yes
 	
 	leader_age_min = 2

--- a/common/static_modifiers/00_static_modifiers.txt
+++ b/common/static_modifiers/00_static_modifiers.txt
@@ -188,7 +188,7 @@ pop_habitability = {
 	planet_pops_upkeep_mult = 1
 
 	# make machines build slow on planet
-	pop_assembly_speed = -1.35
+	pop_assembly_speed = -1.45
 }
 
 # Happiness Levels

--- a/common/static_modifiers/00_static_modifiers.txt
+++ b/common/static_modifiers/00_static_modifiers.txt
@@ -1,0 +1,1506 @@
+# All global modifiers are here.  They are applied from certain game-features.
+#
+# Effects are fully scriptable here.
+
+# The names can NOT be removed or changed since the code references them
+
+##########################################################################
+# Empire Base Modifiers
+##########################################################################
+empire_base = {
+	max_rivalries = 3
+	country_occupation_armies_add = 3
+	local_trade_protection_add = 2
+}
+
+# Only applied to human-controlled empires
+player_empire = {
+}
+
+# Only applied to AI-controlled but playable empires
+playable_ai_empire = {
+	diplomacy_upkeep_mult = -0.5
+}
+
+# Only applied to AI-controlled but playable empires
+non_playable_ai_empire = {
+}
+
+# Per empire size over admin cap
+empire_size_over_cap = {
+	campaigns_cost_mult = 0.01
+	leader_upkeep_empire_size_mult = 0.01
+	leader_cost_empire_size_mult = 0.01
+}
+
+# Per empire size (ignores admin cap)
+empire_size = {
+	rare_edicts_cost_mult = 0.01
+}
+
+# Per navy size
+navy_size = {
+}
+
+# Applies to Awakened Empires too
+fallen_empire_base = {
+	starbases_upkeep_mult = -0.5
+	ships_upkeep_mult = -0.5
+	country_naval_cap_add = 100
+	country_resource_max_add = 100000
+}
+
+##########################################################################
+# Federation
+##########################################################################
+in_federation = {
+}
+
+federation_tax = {
+	country_energy_produces_mult = -0.15
+}
+
+#########################################################################
+# Defensive War
+##########################################################################
+defensive_war = {
+}
+
+##########################################################################
+# High War Exhaustion
+##########################################################################
+high_war_exhaustion = {
+}
+
+##########################################################################
+# Difficulty Modifiers - not applied to vassals of players
+##########################################################################
+
+# For playable empires
+difficulty_grand_admiral = {
+	stations_produces_mult = 1
+	planet_jobs_produces_mult = 1
+	country_naval_cap_mult = 0.6
+	ships_upkeep_mult = -0.4
+	starbase_shipyard_build_cost_mult = -0.4
+	planet_stability_add = 20
+}
+
+difficulty_admiral = {
+	stations_produces_mult = 0.75
+	planet_jobs_produces_mult = 0.75
+	country_naval_cap_mult = 0.45
+	ships_upkeep_mult = -0.3
+	starbase_shipyard_build_cost_mult = -0.3
+	planet_stability_add = 15
+}
+
+difficulty_commodore = {
+	stations_produces_mult = 0.5
+	planet_jobs_produces_mult = 0.5
+	country_naval_cap_mult = 0.3
+	ships_upkeep_mult = -0.2
+	starbase_shipyard_build_cost_mult = -0.2
+	planet_stability_add = 10
+}
+
+difficulty_captain = {
+	stations_produces_mult = 0.25
+	planet_jobs_produces_mult = 0.25
+	country_naval_cap_mult = 0.15
+	ships_upkeep_mult = -0.1
+	starbase_shipyard_build_cost_mult = -0.1
+	planet_stability_add = 5
+}
+
+difficulty_ensign = {
+}
+
+difficulty_cadet_player = {
+	stations_produces_mult = 0.5
+	planet_jobs_produces_mult = 0.5
+	country_naval_cap_mult = 0.5
+	planet_stability_add = 10
+}
+
+# For non-playable empires, scales to setting in country type
+difficulty_grand_admiral_npc = {
+	ship_weapon_damage = 0.50
+	ship_hull_mult = 0.50
+	ship_armor_mult = 0.50
+	ship_shield_mult = 0.50
+}
+
+difficulty_admiral_npc = {
+	ship_weapon_damage = 0.45
+	ship_hull_mult = 0.45
+	ship_armor_mult = 0.45
+	ship_shield_mult = 0.45
+}
+
+difficulty_commodore_npc = {
+	ship_weapon_damage = 0.40
+	ship_hull_mult = 0.40
+	ship_armor_mult = 0.40
+	ship_shield_mult = 0.40
+}
+
+difficulty_captain_npc = {
+	ship_weapon_damage = 0.35
+	ship_hull_mult = 0.35
+	ship_armor_mult = 0.35
+	ship_shield_mult = 0.35
+}
+
+difficulty_ensign_npc = {
+	ship_weapon_damage = 0.30
+	ship_hull_mult = 0.30
+	ship_armor_mult = 0.30
+	ship_shield_mult = 0.30
+}
+
+# Awakened Empires grow weaker over time
+awakened_empire_decadence = {
+	planet_jobs_produces_mult = -0.66
+	country_subject_power_penalty_mult = 2.0
+	ship_weapon_damage = -0.25
+	ship_hull_mult = -0.25
+	ship_armor_mult = -0.25
+	ship_shield_mult = -0.25
+}
+
+
+##########################################################################
+# Pop Modifiers
+##########################################################################
+
+# Base Pop Modifiers
+pop_base = {
+}
+
+# Base Pop Modifiers
+pop_base_with_happiness = {
+}
+
+# At 0% habitability
+pop_habitability = {
+	pop_amenities_usage_mult = 1
+	planet_pops_upkeep_mult = 1
+}
+
+# Happiness Levels
+pop_happiness_positive = {
+	pop_government_ethic_attraction = 0.50
+}
+
+pop_happiness_positive_slave = {
+	pop_ethic_authoritarian_attraction_mult = 1
+}
+
+# Also reduces stability
+pop_happiness_negative = {
+	pop_government_ethic_attraction = -0.50
+}
+
+pop_happiness_negative_slave = {
+	pop_ethic_egalitarian_attraction_mult = 5
+}
+
+recent_refugee = {
+	pop_happiness = 0.1
+}
+
+infiltration_happiness = {
+	pop_happiness = 0.3
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+}
+
+planet_forced_growth = {
+	pop_growth_speed = -0.2
+}
+
+planet_forced_assembly = {
+}
+
+planet_forced_decline = {
+}
+
+# Scales with planet trade value
+branch_office_value = {
+	planet_branch_offices_energy_produces_add = 1
+}
+
+# Only one of the two below will be applied
+has_branch_office = {
+}
+
+has_criminal_branch_office = {
+	planet_crime_add = 25
+}
+
+planet_devastation = {
+	planet_housing_mult = -1
+	planet_amenities_mult = -1
+	trade_value_mult = -1
+	planet_jobs_produces_mult = -1
+	planet_jobs_upkeep_mult = -1
+	pop_growth_speed_reduction = 1
+	planet_immigration_pull_mult = -1
+}
+
+occupation = {
+	pop_happiness = -0.10
+	planet_jobs_produces_mult = -0.5
+	planet_jobs_upkeep_mult = -0.5
+	planet_pops_upkeep_mult = -0.5
+	pop_growth_speed_reduction = 0.5
+	planet_immigration_pull_mult = -0.5
+}
+
+pop_uplifted = {
+	pop_happiness = 0.1
+}
+
+pop_citizen_happiness = {
+	pop_happiness = 1.0
+}
+
+pop_planet_terraforming = {
+	pop_happiness = -0.2
+}
+
+pop_saved_from_slavery = {
+	pop_happiness = 0.1
+} 
+
+pop_saved_from_purge = {
+	pop_happiness = 0.3
+} 
+
+pop_recently_conquered = {
+	pop_happiness = -0.2
+} 
+
+pop_angry_subterranean = {
+	pop_happiness = -0.2
+}
+
+pop_happiness_cheat = {
+	pop_happiness = 0.01
+}
+
+pop_troubled_succession = {
+	pop_happiness = -0.3
+} 
+
+pop_drought = {
+	pop_happiness = -0.2
+}
+
+pop_did_not_kill_stalker = {
+	pop_happiness = -0.2
+}
+
+pop_synth_paranoia = {
+	pop_happiness = -0.2
+}
+
+pop_liberation_fever = {
+	pop_happiness = 0.3
+}
+
+lost_owned_pop_lesser = {
+	pop_happiness = -0.1
+}
+
+lost_owned_pop = {
+	pop_happiness = -0.2
+}
+
+##########################################################################
+# Generated Planet Modifiers
+##########################################################################
+
+hazardous_weather = {
+	pop_environment_tolerance = -0.10
+	pop_happiness = -0.05
+	planet_jobs_energy_produces_mult = 0.20
+	district_generator_max = 4
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_hazardous_weather.dds"
+	icon_frame = 2
+}
+
+dangerous_wildlife = {
+	pop_environment_tolerance = -0.10
+	pop_happiness = -0.05
+	planet_jobs_society_research_produces_mult = 0.20
+
+	icon = "gfx/interface/icons/planet_modifiers/pm_dangerous_wildlife.dds"
+	icon_frame = 2
+}
+
+weak_magnetic_field = {
+	pop_environment_tolerance = -0.05
+	pop_growth_speed = -0.05
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_weak_magnetic_field.dds"
+	icon_frame = 3
+}
+
+strong_magnetic_field = {
+	planet_jobs_energy_produces_mult = 0.05
+	planet_jobs_physics_research_produces_mult = 0.05
+	district_generator_max = 2
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_strong_magnetic_field.dds"
+	icon_frame = 1
+}
+
+unstable_tectonics = {
+	pop_environment_tolerance = -0.10
+	pop_happiness = -0.05
+	planet_jobs_engineering_research_produces_mult = 0.20
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_unstable_tectonics.dds"
+	icon_frame = 3
+}
+
+tidal_locked = {
+	planet_max_districts_mult = -0.30
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_tidal_locked.dds"
+	icon_frame = 3
+}
+
+chthonian_planet = {
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_chthonian_planet.dds"
+	icon_frame = 1
+}
+
+asteroid_impacts = {
+	pop_environment_tolerance = -0.05
+	planet_jobs_minerals_produces_mult = 0.05
+	district_mining_max = 2
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_impacts.dds"
+	icon_frame = 2
+}
+
+extensive_moon_system = {
+	planet_jobs_minerals_produces_mult = 0.10
+	district_mining_max = 2
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_extensive_moon_system.dds"
+	icon_frame = 1
+}
+
+carbon_world = {
+	planet_jobs_minerals_produces_mult = 0.15
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_carbon_world.dds"
+	icon_frame = 1
+}
+
+wild_storms = {
+	pop_environment_tolerance = -0.05
+	pop_happiness = -0.05
+	planet_jobs_physics_research_produces_mult = 0.20
+
+	icon = "gfx/interface/icons/planet_modifiers/pm_wild_storms.dds"
+	icon_frame = 2
+}
+
+mineral_rich = {
+	planet_jobs_minerals_produces_mult = 0.15
+	district_mining_max = 4
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_mineral_rich.dds"
+	icon_frame = 1
+}
+
+ultra_rich = {
+	planet_jobs_minerals_produces_mult = 0.25
+	district_mining_max = 8
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_ultra_rich.dds"
+	icon_frame = 1
+}
+
+mineral_poor = {
+	planet_jobs_minerals_produces_mult = -0.25
+	district_mining_max = -3
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_mineral_poor.dds"
+	icon_frame = 3
+}
+
+titanic_life = {
+	planet_jobs_society_research_produces_mult = 0.25
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_titanic_life.dds"
+	icon_frame = 1
+}
+
+eat_the_titans = {
+	#TODO [CD]
+	#add a special titan hunter job here
+	#planet_resource_food_add = 20
+	district_farming_max = 8
+	planet_jobs_food_produces_mult = 0.3
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_titanic_life.dds"
+	icon_frame = 1
+}
+
+asteroid_belt = {
+	planet_jobs_minerals_produces_mult = 0.10
+	district_mining_max = 3
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+	icon_frame = 1
+}
+
+natural_beauty = {
+	pop_happiness = 0.05
+	planet_immigration_pull_mult = 0.25
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_natural_beauty.dds"
+	icon_frame = 1
+}
+
+atmospheric_aphrodisiac = {
+	pop_environment_tolerance = 0.05
+	pop_growth_speed = 0.10
+	pop_government_ethic_attraction = -0.20
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_atmospheric_aphrodisiac.dds"
+	icon_frame = 1
+}
+
+atmospheric_hallucinogen = {
+	biological_pop_happiness = 0.05
+	planet_jobs_physics_research_produces_mult = 0.10
+	pop_government_ethic_attraction = -0.30
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_atmospheric_hallucinogen.dds"
+	icon_frame = 2
+}
+
+atmospheric_hallucinogen_good = {
+	pop_happiness = 0.10
+	planet_jobs_physics_research_produces_mult = 0.10
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_atmospheric_hallucinogen.dds"
+	icon_frame = 1
+}
+
+lush_planet = {
+	pop_environment_tolerance = 0.10
+	planet_jobs_food_produces_mult = 0.20
+	district_farming_max = 4
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_lush.dds"
+	icon_frame = 1
+}
+
+bleak_planet = {
+	pop_environment_tolerance = -0.05
+	planet_jobs_food_produces_mult = -0.10
+	district_farming_max = -2
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_bleak.dds"
+	icon_frame = 3
+}
+
+irradiated_planet = {
+	pop_environment_tolerance = -0.10
+	biological_pop_happiness = -0.20
+	planet_jobs_food_produces_mult = -0.50
+	district_farming_max = -6
+	district_mining_max = 2
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_irradiated.dds"
+	icon_frame = 3
+}
+
+low_gravity = {
+	planet_buildings_cost_mult = -0.1
+	pop_environment_tolerance = -0.05
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_low_gravity.dds"
+	icon_frame = 2
+}
+
+high_gravity = {
+	planet_buildings_cost_mult = 0.1
+	planet_districts_cost_mult = 0.1
+	pop_environment_tolerance = -0.05
+	planet_max_districts_add = 2
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_high_gravity.dds"
+	icon_frame = 2
+}
+
+##########################################################################
+# Planet Modifiers
+##########################################################################
+
+# Base Planet Modifiers
+planet_base = {
+}
+
+colony_base = {
+}
+
+planet_num_pops = {
+}
+
+migrating_forests = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_lush.dds"
+}
+
+migrating_forests_2 = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_lush.dds"
+}
+
+dead_creatures = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_wasteland.dds"
+}
+
+starship_graveyard = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+organic_starship = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+abandoned_cities = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+}
+
+subterranean_ocean = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_wild_storms.dds"
+}
+
+colony_enclaves = {
+	planet_jobs_minerals_produces_mult = -0.3
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+}
+
+primitive_reservation = {
+	planet_jobs_minerals_produces_mult = -0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+}
+
+atmospheric_ecosystem = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_atmospheric_hallucinogen.dds"
+}
+
+asteroid_life = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+asteroid_coprolite = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+derelict_shipyard = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+junkyard = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+target_range = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_impacts.dds"
+}
+
+ore_freighter = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+aerostat_colonies = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_atmospheric_hallucinogen.dds"
+}
+
+debris_field = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+extreme_storms = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_wild_storms.dds"
+}
+
+precious_moon = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_extensive_moon_system.dds"
+}
+
+asteroid_collision = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_impacts.dds"
+}
+
+microsingularity = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+}
+
+alien_writing = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+}
+
+towed_asteroid = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+nuclear_devastation = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_irradiated.dds"
+}
+
+gamma_ray = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_strong_magnetic_field.dds"
+}
+	
+greenhouse_effect = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_atmospheric_hallucinogen.dds"
+}
+
+ammonia_biosphere = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_atmospheric_hallucinogen.dds"
+}
+
+silicon_lifeforms = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_carbon_world.dds"
+}
+
+colony_ruins = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+}
+
+alien_mural = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+}
+
+damaged_ecology = {
+	pop_happiness = -0.2
+	icon = "gfx/interface/icons/planet_modifiers/pm_wasteland.dds"
+	icon_frame = 3
+}
+
+friendly_trees = {
+	pop_happiness = 0.2
+	icon = "gfx/interface/icons/planet_modifiers/pm_lush.dds"
+}
+
+subterranean_civilization = {
+	planet_jobs_society_research_produces_mult = 0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_hollow_planet.dds"
+}
+
+subterranean_expansion = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_hollow_planet.dds"
+	planet_max_districts_add = 3 
+}
+
+gas_giant_civ = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_chthonian_planet.dds"
+}
+
+gas_giant_colony = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_chthonian_planet.dds"
+}
+
+abandoned_terraforming = {
+	planet_jobs_food_produces_mult = -0.2
+	pop_happiness = -0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_impacts.dds"
+	icon_frame = 3
+}
+
+gaia_world = {
+	pop_growth_speed = 0.20
+	icon = "gfx/interface/icons/planet_modifiers/pm_lush.dds"
+}
+
+mutant_stalker = {
+	pop_happiness = -0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_dangerous_wildlife.dds"
+	icon_frame = 3
+}
+
+wasteland_infrastructure = {
+	planet_districts_cost_mult = -0.25
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+}
+
+wasteland_radiation = {
+	biological_pop_happiness = -0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_irradiated.dds"
+	icon_frame = 3
+}
+
+wasteland_orbital_debris = {
+	planet_buildings_cost_mult = 0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_impacts.dds"
+}
+
+upliftable_species = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+}
+
+assist_research = {
+	planet_jobs_physics_research_produces_mult = 0.10
+	planet_jobs_society_research_produces_mult = 0.10
+	planet_jobs_engineering_research_produces_mult = 0.10
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_assist_research.dds"
+	icon_frame = 1
+}
+
+ancient_automation = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_robots.dds"
+	icon_frame = 2
+}
+
+ancient_factory = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+	icon_frame = 2
+}
+
+robot_workers = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_robots.dds"
+	icon_frame = 2
+}
+
+ancient_forgeworld = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+	icon_frame = 2
+}
+
+ancient_weapon = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+	icon_frame = 2
+}
+
+holy_planet = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_consecrated_worlds.dds"
+	icon_frame = 3
+}
+
+terraforming_candidate = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_from_space.dds"
+	icon_frame = 1
+	important = yes			# if present on a planet, show the planet's nameplate
+}
+
+planet_uncertain_past = {
+	planet_jobs_physics_research_produces_mult = 0.1
+	planet_jobs_society_research_produces_mult = 0.1
+	planet_jobs_engineering_research_produces_mult = 0.1
+	pop_happiness = -0.15
+
+	icon = "gfx/interface/icons/planet_modifiers/pm_irradiated.dds"
+	icon_frame = 2
+}
+
+recent_quake = {
+	pop_happiness = -0.05
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_unstable_tectonics.dds"
+	icon_frame = 3
+}
+
+recent_comet = {
+	pop_happiness = 0.1
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+	icon_frame = 1
+}
+
+recent_impact = {
+	pop_happiness = -0.05
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_impacts.dds"
+	icon_frame = 3
+}
+
+magnetic_research_boost = {
+	planet_jobs_physics_research_produces_mult = 0.2
+	planet_jobs_society_research_produces_mult = 0.2
+	planet_jobs_engineering_research_produces_mult = 0.2
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_strong_magnetic_field.dds"
+	icon_frame = 1
+}
+
+magnetic_disruption = {
+	pop_happiness = -0.05
+	planet_jobs_physics_research_produces_mult = -0.1
+	planet_jobs_society_research_produces_mult = -0.1
+	planet_jobs_engineering_research_produces_mult = -0.1
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_strong_magnetic_field.dds"
+	icon_frame = 3
+}
+
+forest_fire = {
+	planet_jobs_food_produces_mult = -0.2
+	icon = "gfx/interface/icons/planet_modifiers/pm_wasteland.dds"
+	icon_frame = 3
+}
+
+nationalist_corruption = {
+	planet_jobs_produces_mult = -0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_nationalist_corruption.dds"
+	icon_frame = 3
+}
+
+planet_separatist_strikes = {
+	planet_jobs_produces_mult = -0.4
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_separatist_supporter.dds"
+	icon_frame = 3
+}
+
+planet_separatist_supporter = {
+	pop_happiness = -0.1
+	icon = "gfx/interface/icons/planet_modifiers/pm_planet_separatist_supporter.dds"
+	icon_frame = 3
+}
+sector_separatist_supporter = {
+	pop_happiness = -0.1
+	icon_frame = 3
+}
+
+stellarite_high_temp = {
+	pop_happiness = -0.25
+	pop_environment_tolerance = -0.25
+	icon = "gfx/interface/icons/planet_modifiers/pm_unstable_tectonics.dds"
+	icon_frame = 3
+}
+
+stellarite_low_temp = {
+	pop_happiness = -0.25
+	pop_environment_tolerance = -0.25
+	icon = "gfx/interface/icons/planet_modifiers/pm_carbon_world.dds"
+	icon_frame = 3
+}
+
+# Scales on ratio of new to old colonies
+old_colony = {
+	planet_emigration_push_add = 100
+}
+
+# Does not scale
+new_colony = {
+	planet_immigration_pull_add = 100
+}
+
+# Stability ( 0 - 100 )
+planet_stability_no_happiness_low = {
+	planet_jobs_produces_mult = -0.5
+}
+
+planet_stability_no_happiness_high = {
+	planet_jobs_produces_mult = 0.30
+}
+
+planet_stability_low = {
+	planet_jobs_produces_mult = -0.5
+	trade_value_mult = -0.5
+	planet_emigration_push_add = 100
+}
+
+planet_stability_high = {
+	planet_jobs_produces_mult = 0.30
+	trade_value_mult = 0.30
+	planet_immigration_pull_add = 20
+}
+
+planet_crime = {
+}
+
+planet_crime_no_happiness = {
+}
+
+
+# Amenities ( 25% - 200% of required)
+planet_amenities_no_happiness_low = {
+	planet_stability_add = -50
+}
+
+planet_amenities_no_happiness_high = {
+	planet_stability_add = 20
+}
+
+planet_amenities_low = {
+	pop_happiness = -0.50
+}
+
+planet_amenities_high = {
+	pop_citizen_happiness = 0.20
+}
+
+# Housing ( 25% - 200% of required)
+planet_housing_no_happiness_low = {
+	planet_stability_add = -20
+}
+
+planet_housing_no_happiness_high = {
+	planet_immigration_pull_mult = 0.25
+}
+
+planet_housing_low = {
+	planet_stability_add = -20
+}
+
+planet_housing_high = {
+	planet_immigration_pull_mult = 0.25
+}
+
+# Overcrowding
+planet_overcrowded = {
+	planet_emigration_push_add = 50
+}
+
+# Per missing job
+planet_employment_no_happiness_low = {
+	planet_emigration_push_add = 5
+}
+
+planet_employment_no_happiness_high = {	
+	planet_immigration_pull_add = 5
+}
+
+planet_employment_low = {
+	planet_emigration_push_add = 5
+}
+
+planet_employment_high = {
+	planet_immigration_pull_add = 5
+}
+
+land_appropriation = {
+	planet_immigration_pull_mult = 1
+	icon = "gfx/interface/icons/planet_modifiers/pm_land_appropriated.dds"
+}
+
+vultaum_homeworld = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+}
+
+vultaum_minerals = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_impacts.dds"
+}
+
+vultaum_energy = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+yuht_homeworld = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+}
+
+yuht_minerals = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+yuht_energy = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+first_league_homeworld = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+	country_society_research_produces_add = 10
+	country_physics_research_produces_add = 10
+	country_engineering_research_produces_add = 10
+}
+
+first_league_minerals = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+first_league_energy = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+irassian_homeworld = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_factory.dds"
+}
+
+irassian_minerals = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+irassian_energy = {
+	icon = "gfx/interface/icons/planet_modifiers/pm_asteroid_belt.dds"
+}
+
+##########################################################################
+# Leader Skill Modifiers
+##########################################################################
+
+skill_admiral = {
+	ship_fire_rate_mult = 0.03
+}
+
+skill_general = {
+	army_damage_mult = 0.05
+}
+
+skill_scientist = {
+	all_technology_research_speed = 0.02
+	science_ship_survey_speed = 0.10
+}
+
+skill_governor = {
+	planet_jobs_produces_mult = 0.02
+	planet_crime_add = -3
+}
+
+skill_ruler = {
+	edict_length_mult = 0.05
+	country_unity_produces_mult = 0.03
+}
+
+leader_skills_spawn = {
+}
+
+##########################################################################
+# Rank modifiers
+##########################################################################
+army_rank_regular = {
+}
+
+army_rank_experienced = {
+	army_damage_mult = 0.1
+	army_morale = 0.1
+}
+
+army_rank_veteran = {
+	army_health = 0.1
+	army_damage_mult = 0.2
+	army_morale = 0.2
+}
+
+army_rank_elite = {
+	army_health = 0.2
+	army_damage_mult = 0.4
+	army_morale = 0.4
+}
+
+ship_rank_regular = {
+}
+
+ship_rank_experienced = {
+	ship_weapon_damage = 0.1
+}
+
+ship_rank_veteran = {
+	ship_weapon_damage = 0.2
+	ship_hull_mult = 0.05
+	ship_evasion_mult = 0.05
+}
+
+ship_rank_elite = {
+	ship_weapon_damage = 0.4
+	ship_hull_mult = 0.10
+	ship_evasion_mult = 0.10
+}
+
+
+##########################################################################
+# Country modifiers
+##########################################################################
+over_starbase_capacity = {
+	starbases_upkeep_mult = 0.25
+}
+
+ruler_ship = {
+	ship_weapon_damage = 0.5
+	ship_hull_mult = 0.5
+	ship_shield_mult = 0.5
+	ship_armor_mult = 0.5
+}
+
+ruler_station = {
+	ship_weapon_damage = 0.5
+	ship_hull_mult = 0.5
+	ship_shield_mult = 0.5
+	ship_armor_mult = 0.5
+}
+
+extradimensionals_defeated = {
+	pop_happiness = 0.2
+}
+
+prethoryn_defeated = {
+	pop_happiness = 0.2
+}
+
+subterranean_tech_transaction = {
+	planet_jobs_engineering_research_produces_mult = -0.30
+	icon = "gfx/interface/icons/modifiers/mod_resource_engineering_research_mult.dds"
+	icon_frame = 3
+}
+
+sponsored_rebels = {
+	country_base_minerals_produces_add = 20
+	country_base_energy_produces_add = 20
+	ships_upkeep_mult = -0.25
+	armies_upkeep_mult = -0.5
+	country_naval_cap_mult = 1.0
+	armies_cost_mult = -0.25
+	planet_army_build_speed_mult = 1.0
+	country_base_influence_produces_add = 3
+}
+
+recently_liberated = {
+	pop_government_ethic_attraction = 0.5
+}
+
+ai_strength = {
+	planet_jobs_minerals_produces_mult = 10
+	planet_jobs_energy_produces_mult = 10
+	planet_jobs_physics_research_produces_mult = 5
+	planet_jobs_society_research_produces_mult = 5
+	planet_jobs_engineering_research_produces_mult = 5
+	country_naval_cap_mult = 1
+}
+
+nomad_strength = {
+	ship_weapon_damage = 1.25
+	ship_hull_mult = 1.25
+}
+
+fleet_maneuvers_recruitment = {
+	icon = "gfx/interface/icons/modifiers/mod_pop_war_happiness.dds"
+	icon_frame = 1
+	ships_upkeep_mult = -0.2
+	starbase_shipyard_build_speed_mult = 0.2
+}
+
+fleet_maneuvers = {
+	icon = "gfx/interface/icons/modifiers/mod_navy_size_add.dds"
+	icon_frame = 1
+	ship_fire_rate_mult = 0.10
+}
+
+maneuvers_canceled = {
+	icon = "gfx/interface/icons/modifiers/mod_country_insult_efficiency.dds"
+	country_unity_produces_mult = -0.05
+	ship_fire_rate_mult = -0.05
+}
+
+maneuvers_no_protest = {
+	icon = "gfx/interface/icons/modifiers/mod_country_insult_efficiency.dds"
+	country_unity_produces_mult = -0.15
+}
+
+marauder_1_tribute = {
+}
+
+marauder_2_tribute = {
+}
+
+marauder_3_tribute = {
+}
+
+marauder_skirmishing = {
+	ship_fire_rate_mult = 0.10
+}
+
+sentinel_data = {
+	damage_vs_country_type_swarm_mult = 0.2
+}
+
+enclave_trade_1_xur = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_exotic_gases_produces_add = 1
+	country_base_energy_produces_add = -10
+}
+
+enclave_trade_2_xur = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_exotic_gases_produces_add = 2
+	country_base_energy_produces_add = -20
+}
+
+enclave_trade_3_xur = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_exotic_gases_produces_add = 3
+	country_base_energy_produces_add = -30
+}
+
+enclave_trade_4_xur = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_exotic_gases_produces_add = 4
+	country_base_energy_produces_add = -40
+}
+
+enclave_trade_5_xur = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_exotic_gases_produces_add = 5
+	country_base_energy_produces_add = -50
+}
+
+enclave_trade_1_rig = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_volatile_motes_produces_add = 1
+	country_base_energy_produces_add = -10
+}
+
+enclave_trade_2_rig = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_volatile_motes_produces_add = 2
+	country_base_energy_produces_add = -20
+}
+
+enclave_trade_3_rig = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_volatile_motes_produces_add = 3
+	country_base_energy_produces_add = -30
+}
+
+enclave_trade_4_rig = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_volatile_motes_produces_add = 4
+	country_base_energy_produces_add = -40
+}
+
+enclave_trade_5_rig = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_volatile_motes_produces_add = 5
+	country_base_energy_produces_add = -50
+}
+
+enclave_trade_1_mut = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_rare_crystals_produces_add = 1
+	country_base_energy_produces_add = -10
+}
+
+enclave_trade_2_mut = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_rare_crystals_produces_add = 2
+	country_base_energy_produces_add = -20
+}
+
+enclave_trade_3_mut = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_rare_crystals_produces_add = 3
+	country_base_energy_produces_add = -30
+}
+
+enclave_trade_4_mut = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_rare_crystals_produces_add = 4
+	country_base_energy_produces_add = -40
+}
+
+enclave_trade_5_mut = {
+	icon = "gfx/interface/icons/modifiers/mod_country_previous_deals.dds"
+	country_base_rare_crystals_produces_add = 5
+	country_base_energy_produces_add = -50
+}
+
+#applied based on the "should_apply_neighbor_rival_modifier" game rule
+#scales with number of rivals that are bordering the country
+per_neighbor_rival = {
+	country_unity_produces_mult = 0.1
+}
+
+# Ghost Signal Pop Modifier
+pop_ghost_signal_5 = {
+	planet_jobs_minerals_produces_mult = -0.70
+	planet_jobs_energy_produces_mult = -0.70
+	planet_jobs_physics_research_produces_mult = -0.70
+	planet_jobs_society_research_produces_mult = -0.70
+	planet_jobs_engineering_research_produces_mult = -0.70
+	planet_jobs_unity_produces_mult = -0.70
+	pop_government_ethic_attraction = -0.70
+}
+
+pop_ghost_signal_4 = {
+	planet_jobs_minerals_produces_mult = -0.55
+	planet_jobs_energy_produces_mult = -0.55
+	planet_jobs_physics_research_produces_mult = -0.55
+	planet_jobs_society_research_produces_mult = -0.55
+	planet_jobs_engineering_research_produces_mult = -0.55
+	planet_jobs_unity_produces_mult = -0.55
+	pop_government_ethic_attraction = -0.55
+}
+
+pop_ghost_signal_3 = {
+	planet_jobs_minerals_produces_mult = -0.40
+	planet_jobs_energy_produces_mult = -0.40
+	planet_jobs_physics_research_produces_mult = -0.40
+	planet_jobs_society_research_produces_mult = -0.40
+	planet_jobs_engineering_research_produces_mult = -0.40
+	planet_jobs_unity_produces_mult = -0.40
+	pop_government_ethic_attraction = -0.40
+}
+
+pop_ghost_signal_2 = {
+	planet_jobs_minerals_produces_mult = -0.25
+	planet_jobs_energy_produces_mult = -0.25
+	planet_jobs_physics_research_produces_mult = -0.25
+	planet_jobs_society_research_produces_mult = -0.25
+	planet_jobs_engineering_research_produces_mult = -0.25
+	planet_jobs_unity_produces_mult = -0.25
+	pop_government_ethic_attraction = -0.25
+}
+
+pop_ghost_signal_1 = {
+	planet_jobs_minerals_produces_mult = -0.10
+	planet_jobs_energy_produces_mult = -0.10
+	planet_jobs_physics_research_produces_mult = -0.10
+	planet_jobs_society_research_produces_mult = -0.10
+	planet_jobs_engineering_research_produces_mult = -0.10
+	planet_jobs_unity_produces_mult = -0.10
+	pop_government_ethic_attraction = -0.10
+}
+
+ship_ghost_signal_5 = {
+	ship_fire_rate_mult = -0.5
+	ship_tracking_add = -5
+}
+
+ship_ghost_signal_4 = {
+	ship_fire_rate_mult = -0.4
+	ship_tracking_add = -4
+}
+
+ship_ghost_signal_3 = {
+	ship_fire_rate_mult = -0.3
+	ship_tracking_add = -3
+}
+
+ship_ghost_signal_2 = {
+	ship_fire_rate_mult = -0.2
+	ship_tracking_add = -2
+}
+
+ship_ghost_signal_1 = {
+	ship_fire_rate_mult = -0.1
+	ship_tracking_add = -1
+}
+
+synth_planet_paranoia = {
+	planet_stability_add = -20
+	icon_frame = 3
+	icon = "gfx/interface/icons/planet_modifiers/pm_unrest.dds"
+}
+
+pop_ghost_signal_5_machine = {
+	planet_jobs_minerals_produces_mult = -0.40
+	planet_jobs_energy_produces_mult = -0.40
+	planet_jobs_physics_research_produces_mult = -0.40
+	planet_jobs_society_research_produces_mult = -0.40
+	planet_jobs_engineering_research_produces_mult = -0.40
+}
+
+pop_ghost_signal_4_machine = {
+	planet_jobs_minerals_produces_mult = -0.25
+	planet_jobs_energy_produces_mult = -0.25
+	planet_jobs_physics_research_produces_mult = -0.25
+	planet_jobs_society_research_produces_mult = -0.25
+	planet_jobs_engineering_research_produces_mult = -0.25
+}
+
+
+
+##########################################################################
+# Fallen Empire Tasks & Requests Modifiers
+##########################################################################
+fallen_empire_gift_databanks = {
+	planet_jobs_physics_research_produces_mult = 0.25
+	planet_jobs_society_research_produces_mult = 0.25
+	planet_jobs_engineering_research_produces_mult = 0.25
+}
+
+gave_up_scientist_xenophobe = {
+	pop_happiness = -0.1
+}
+
+gave_up_pop = {
+	pop_happiness = -0.1
+}
+
+gave_up_pop_xenophile = {
+	pop_happiness = -0.05
+}
+
+gave_up_pop_xenophobe = {
+	pop_happiness = -0.2
+}
+
+fe_gift_ship = {
+	ships_upkeep_mult = -0.33
+}
+
+machine_empire_inoculations_xenophobe = {
+	biological_pop_happiness = -0.1
+}
+
+machine_empire_inoculations = {
+	biological_pop_happiness = -0.05
+}
+
+machine_empire_health_boost = {
+	pop_growth_speed = 0.05
+	leader_age = 10
+}
+
+machine_empire_mutations = {
+	leader_age = -10
+	pop_growth_speed = -0.10
+	pop_happiness = -0.20
+}
+
+machine_empire_code_rewrite = {
+	planet_pops_robotics_upkeep_mult = 0.10
+}
+
+machine_empire_code_improvements = {
+	planet_jobs_robotic_produces_mult = 0.05
+}
+
+machine_empire_code_bugs = {
+	planet_pops_robotics_upkeep_mult = 0.05
+	planet_jobs_robotic_produces_mult = -0.20
+}
+
+dportal_trade_normal = {
+	#planet_jobs_trade_value_produces_mult = 0.5 #Trade is actually added to the portal researcher job
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_resources.dds"
+	icon_frame = 1
+}
+
+dportal_trade_low = {
+	#planet_jobs_trade_value_produces_mult = 0.25
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_resources.dds"
+	icon_frame = 2
+}
+
+dportal_trade_high = {
+	#planet_jobs_trade_value_produces_mult = 0.75
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_resources.dds"
+	icon_frame = 1
+}
+
+dportal_trade_crisis = {
+	pop_growth_speed = 0.25
+	
+	icon = "gfx/interface/icons/planet_modifiers/pm_expel_population.dds"
+	icon_frame = 2
+}
+
+fe_ship_cost_modifier = {
+	ships_upkeep_mult = -0.5
+	starbase_shipyard_build_cost_mult = -0.5
+}

--- a/common/static_modifiers/00_static_modifiers.txt
+++ b/common/static_modifiers/00_static_modifiers.txt
@@ -186,6 +186,9 @@ pop_base_with_happiness = {
 pop_habitability = {
 	pop_amenities_usage_mult = 1
 	planet_pops_upkeep_mult = 1
+
+	# make machines build slow on planet
+	pop_assembly_speed = -1.35
 }
 
 # Happiness Levels

--- a/common/traits/02_species_traits_basic_characteristics.txt
+++ b/common/traits/02_species_traits_basic_characteristics.txt
@@ -1,0 +1,80 @@
+# species_potential_add = {}
+# show the trait to add to species when genemodding or randomizing traits.
+# Scopes are this = species, from = country performing the modification.
+# default = always=yes
+
+# species_possible_remove = {}
+# allow to remove the trait when genemodding.
+# Scopes are this = species, from = country performing the modification.
+# default = always=yes
+
+trait_hive_mind = {
+	cost = 0
+	sorting_priority = 20
+	
+	initial = no
+	randomized = no
+	modification = no
+	forced_happiness = yes
+	
+	modifier = {}
+	
+	leader_age_min = 10
+	leader_age_max = 20
+	
+	allowed_archetypes = { BIOLOGICAL }
+	ai_weight = {
+		weight = 0
+	}
+
+	icon = "gfx/interface/icons/traits/leader_traits/leader_trait_ruler_hive_mind.dds"
+}
+
+trait_machine_unit = {
+	cost = 0
+	sorting_priority = 20
+	initial = no
+	randomized = no
+	modification = no
+	immortal_leaders = yes
+	icon = "gfx/interface/icons/traits/trait_machine_unit.dds"
+	allowed_archetypes = { MACHINE }
+
+	forced_happiness = yes
+	modifier = {
+		pop_environment_tolerance = 0.20
+	}
+}
+
+trait_mechanical = {
+	cost = 0
+	sorting_priority = 20
+	
+	initial = no
+	randomized = no
+	modification = no
+	immortal_leaders = yes
+
+	allowed_archetypes = { ROBOT }
+	
+	modifier = {
+		pop_environment_tolerance = 2.0
+	}
+}
+
+trait_syncretic_proles = {
+	cost = 1
+	potential_crossbreeding_chance = 0.33
+	opposites = { "trait_intelligent" "trait_erudite" "trait_natural_engineers" "trait_natural_physicists" "trait_natural_sociologists" }
+	initial = no
+	modification = yes
+	species_potential_add = { always = no }
+	icon = "gfx/interface/icons/traits/trait_primitive.dds"
+	allowed_archetypes = { BIOLOGICAL }
+	
+	custom_tooltip = TRAIT_SYNCRETIC_PROLES_EFFECT
+	modifier = {
+		pop_happiness = 0.10
+		planet_jobs_produces_mult = 0.10
+	}
+}

--- a/common/traits/02_species_traits_basic_characteristics.txt
+++ b/common/traits/02_species_traits_basic_characteristics.txt
@@ -42,7 +42,7 @@ trait_machine_unit = {
 
 	forced_happiness = yes
 	modifier = {
-		pop_environment_tolerance = 0.20
+		pop_environment_tolerance = 0.30 # originally 2.00, reduced to make machines care about habitability
 	}
 }
 

--- a/events/sundown_events.txt
+++ b/events/sundown_events.txt
@@ -10,8 +10,8 @@ namespace = sundown
 
 country_event = {
 	id = sundown.10
-	title = "Zro found"
-	desc = "We found some zro"
+	title = event_sundown_10_title
+	desc = event_sundown_10_desc
 	picture = GFX_evt_mining_station
 	
 	trigger = {
@@ -24,7 +24,7 @@ country_event = {
 	}
 
 	option = {
-		name = "cool"
+		name = event_sundown_10_option_accept
 		random_planet_within_border = {
 			limit = {
 				is_colonizable = no

--- a/localisation/sundown_l_english.yml
+++ b/localisation/sundown_l_english.yml
@@ -1,0 +1,5 @@
+# contains localization for the sundown balance mod
+l_english:
+ event_sundown_10_title "Zro Deposits Located on [Root.GetHomeWorldName]"
+ event_sundown_10_desc "Following the successful discovery of zro distillation, our researchers have discovered a deposit of the resource on our homeworld."
+ event_sundown_10_option_accept "Cool."


### PR DESCRIPTION
Addresses #2.

Specifically, makes machine empires do the following:
- Have a habitability preference.
- Only gain 30% habitability instead of 200%.
- When habitability is at 0%, pop assembly speed is reduced by 145%. This accounts for all possible modifiers to pop assembly speed.

Numbers are as-of-yet untested.

Also adds localization to the zro event.